### PR TITLE
feat: openiris impl, windows builds, refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 target/
 /.vscode/
 /.direnv/
+.idea/
 node_modules/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,13 +3,6 @@
 version = 4
 
 [[package]]
-name = "Phoenix"
-version = "0.1.0"
-dependencies = [
- "opencv",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -41,7 +34,9 @@ name = "camera"
 version = "0.1.0"
 dependencies = [
  "log",
+ "nom",
  "opencv",
+ "replace_with",
  "serialport",
 ]
 
@@ -205,6 +200,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -312,6 +316,12 @@ name = "regex-syntax"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
+name = "replace_with"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a8614ee435691de62bcffcf4a66d91b3594bf1428a5722e79103249a095690"
 
 [[package]]
 name = "scopeguard"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,16 +1,10 @@
-[package]
-name = "Phoenix"
-version = "0.1.0"
-edition = "2021"
-
 [workspace.dependencies]
 log = { version = "0.4.27", default-features = false }
+opencv = { version = "0.94.4" }
 
 [workspace]
+resolver = "3"
 members = [
     "crates/logger",
     "crates/camera",
 ]
-
-[dependencies]
-opencv = { version = "0.94.3", features = ["highgui"] }

--- a/crates/camera/BUILDING.md
+++ b/crates/camera/BUILDING.md
@@ -1,0 +1,17 @@
+## Building on Windows
+Refer to the [opencv-rust documentation](https://github.com/twistedfall/opencv-rust/blob/master/INSTALL.md), alternatively follow the following guide:
+
+- install vcpkg
+    - clone it to any location for tooling (e.g. C:/dev/tools)
+        - `git clone https://github.com/microsoft/vcpkg.git`
+    - run its bootstrap scripts
+        - `cd vcpkg`
+        - `.\bootstrap-vcpkg.bat`
+- install [cargo-vcpkg](https://github.com/mcgoo/cargo-vcpkg)
+    - `cargo install cargo-vcpkg`
+- install llvm
+    - `winget install llvm`
+- install opencv4 via vcpkg (see `Cargo.toml`)
+    - `cargo vcpkg build`
+- finally, build the crate
+    - `cargo build`

--- a/crates/camera/Cargo.toml
+++ b/crates/camera/Cargo.toml
@@ -1,9 +1,23 @@
 [package]
 name = "camera"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 log = { workspace = true }
-opencv = { version = "0.94.4" }
-serialport = { version = "4.7.1" }
+opencv = { workspace = true }
+
+nom = "8.0.0"
+replace_with = "0.1.7"
+serialport = "4.7.1"
+
+
+[package.metadata.vcpkg]
+git = "https://github.com/microsoft/vcpkg"
+rev = "6760f636e7bcd0dd034c5c0906f6174009465c29"
+dependencies = ["opencv4[contrib,nonfree]"]
+
+[package.metadata.vcpkg.target]
+x86_64-pc-windows-msvc = { triplet = "x64-windows-static-md", install = [
+    "opencv4[contrib,nonfree]",
+] }

--- a/crates/camera/src/backends/noop.rs
+++ b/crates/camera/src/backends/noop.rs
@@ -1,16 +1,26 @@
 use crate::*;
 
+#[derive(Debug)]
 pub struct NoOpCamera {}
 
 unsafe impl Send for NoOpCamera {}
 unsafe impl Sync for NoOpCamera {}
 
 impl CameraHandler for NoOpCamera {
+    fn init() -> Self
+    where
+        Self: Sized,
+    {
+        Self {}
+    }
+
+    fn get_frame(&mut self) -> Result<Vec<u8>, CameraState> {
+        Ok(vec![])
+    }
+
+    fn connect(&mut self, _source: String) -> Result<(), CameraState> {
+        Ok(())
+    }
+
     fn disconnect(&mut self) {}
-
-    fn init() -> Self where Self: Sized {return Self {}}
-
-    fn get_frame(&mut self) -> Result<Vec<u8>, CameraState> {return Ok(vec![])}
-
-    fn connect(&mut self, _source: String) -> Result<(), CameraState> {return Ok(())}
 }

--- a/crates/camera/src/backends/opencv.rs
+++ b/crates/camera/src/backends/opencv.rs
@@ -1,65 +1,110 @@
 // Look i am not happy about this either
 // In a perfect world we ditch OpenCV and roll something custom
-// But we dont live in a perfect world and dealing with different image coddecs is a huge pain
-// Even when writing this for the first time it is already due for a massvice refactor to nuke OpenCV
+// But we dont live in a perfect world and dealing with different image coddecs
+// is a huge pain Even when writing this for the first time it is already due
+// for a massvice refactor to nuke OpenCV
+
+use opencv::{
+    prelude::*,
+    videoio::{CAP_FFMPEG, VideoCapture},
+};
 
 use crate::*;
-use opencv::prelude::*;
-use opencv::videoio::{VideoCapture, CAP_FFMPEG};
 
+#[derive(Debug)]
+enum InternalState {
+    Waiting,
+    Connected {
+        capture: VideoCapture,
+        source: String,
+    },
+}
+
+#[derive(Debug)]
 pub struct OpenCVCamera {
-    capture: VideoCapture,
-    capture_source: String,
+    state: InternalState,
 }
 
 unsafe impl Send for OpenCVCamera {}
 unsafe impl Sync for OpenCVCamera {}
 
 impl CameraHandler for OpenCVCamera {
-    fn init() -> Self where Self: Sized {
-        return Self {
-            capture_source: String::new(),
-            capture: VideoCapture::default().unwrap(),
-        };
+    fn init() -> Self
+    where
+        Self: Sized,
+    {
+        Self {
+            state: InternalState::Waiting,
+        }
     }
 
     fn get_frame(&mut self) -> Result<Vec<u8>, CameraState> {
-        // FIXME: make sure the camera is open
-        let mut mat = Mat::default();
-        match self.capture.read(&mut mat) {
-            Ok(true) => {
-                if mat.size().unwrap().width > 0 && mat.size().unwrap().height > 0 {
-                    return Ok(mat.data_bytes().unwrap().to_vec());
+        match self.state {
+            InternalState::Connected {
+                ref mut capture, ..
+            } => {
+                let mut mat = Mat::default();
+
+                match capture.read(&mut mat) {
+                    Ok(true) => {
+                        if mat.size().unwrap().width > 0 && mat.size().unwrap().height > 0 {
+                            return Ok(mat.data_bytes().unwrap().to_vec());
+                        }
+
+                        Err(CameraState::ReadFailed)
+                    }
+                    Ok(false) => Err(CameraState::ReadFailed),
+                    Err(e) => Err(CameraState::Error(format!("Failed to read frame: {}", e))),
                 }
-                return Err(CameraState::ReadFailed);
             }
-            Ok(false) => {return Err(CameraState::ReadFailed)}
-            Err(e) => {return Err(CameraState::Error(format!("Failed to read frame: {}", e)))}
+            InternalState::Waiting => Err(CameraState::Disconnected),
         }
     }
 
     fn connect(&mut self, source: String) -> Result<(), CameraState> {
-        if self.capture_source == source {
-            log::trace!("Skipping connection, already connected to {}", source);
-            return Ok(());
-        }
+        match self.state {
+            InternalState::Connected {
+                source: ref current_source,
+                ..
+            } if current_source == &source => {
+                log::trace!("Skipping connection, already connected to {source}");
+                Ok(())
+            }
+            InternalState::Connected { .. } => {
+                // todo connect to other source here?
+                Ok(())
+            }
+            InternalState::Waiting => {
+                // TODO: Ping the host to see if it is alive
 
-        // TODO: Ping the host to see if it is alive
-        self.capture_source = source.clone();
-        match self.capture.open_file(&source, CAP_FFMPEG) {
-            Ok(state) => {
-                if state {return Ok(())};
-                match self.capture.is_opened() {
-                    Ok(true) => {return Ok(())}
-                    Ok(false) => {return Err(CameraState::Timeout)}
-                    Err(e) => {return Err(CameraState::Error(format!("Failed to open camera: {}", e)))}
+                let mut capture = VideoCapture::default().unwrap();
+
+                if let Err(e) = match capture.open_file(&source, CAP_FFMPEG) {
+                    Ok(state) if state => Ok(()),
+                    Ok(_) => match capture.is_opened() {
+                        // todo: is this branch really necessary?
+                        Ok(true) => Ok(()),
+                        Ok(false) => Err(CameraState::Timeout),
+                        Err(e) => Err(CameraState::Error(format!("Failed to open camera: {e}"))),
+                    },
+                    Err(e) => Err(CameraState::Error(format!("Failed to open camera: {e}"))),
+                } {
+                    Err(e)
+                } else {
+                    self.state = InternalState::Connected { capture, source };
+
+                    Ok(())
                 }
             }
-            Err(e) => {return Err(CameraState::Error(format!("Failed to open camera: {}", e)))}
         }
     }
 
     fn disconnect(&mut self) {
-        self.capture.release().unwrap();
+        if let InternalState::Connected {
+            ref mut capture, ..
+        } = self.state
+        {
+            capture.release().unwrap()
+        }
     }
 }

--- a/crates/camera/src/backends/openiris.rs
+++ b/crates/camera/src/backends/openiris.rs
@@ -1,5 +1,199 @@
-use serialport::SerialPort;
+use std::{io, time::Duration};
 
+use log::{error, info, trace, warn};
+use nom::{IResult, Parser, bytes, number, sequence};
+use serialport::{FlowControl, SerialPort};
+
+use crate::{CameraHandler, CameraState};
+
+// Serial communication protocol:
+// header-begin (2 bytes)
+// header-type (2 bytes)
+// packet-size (2 bytes)
+// packet (packet-size bytes)
+// https://github.com/EyeTrackVR/OpenIris/blob/5da262c8daf27ea2cb060ec2e41a19a1c1c3db29/ESP/lib/src/io/Serial/SerialManager.cpp#L31
+
+// header + header type
+const ETVR_HEADER_FRAME: &[u8] = &[0xFF, 0xA0, 0xFF, 0xA1];
+const BAUD_RATE: u32 = if cfg!(target_os = "macos") {
+    // as per EyeTrackVR python: higher baud rate not working on macOS
+    115_200
+} else {
+    3_000_000
+};
+
+type SerialPortVariant = Box<dyn SerialPort>;
+
+#[derive(Debug)]
 pub struct OpenIrisCamera {
-    pub port: Box<dyn SerialPort>,
+    port: Option<SerialPortVariant>,
 }
+
+impl CameraHandler for OpenIrisCamera {
+    fn init() -> Self
+    where
+        Self: Sized,
+    {
+        Self { port: None }
+    }
+
+    fn get_frame(&mut self) -> Result<Vec<u8>, CameraState> {
+        if let Some(port) = self.port.as_mut() {
+            let mut frame = get_frame(port)?;
+            Ok(std::mem::take(&mut frame))
+        } else {
+            Err(CameraState::Disconnected)
+        }
+    }
+
+    fn connect(&mut self, source: String) -> Result<(), CameraState> {
+        if self.port.is_none() {
+            let source = source.as_str();
+            info!("connecting to {source}");
+
+            // todo: figure out why the baud rate gets reset to 9600
+            match serialport::new(source, BAUD_RATE)
+                .timeout(Duration::from_millis(100))
+                .flow_control(FlowControl::None)
+                .open()
+            {
+                Ok(port) => {
+                    info!("connected to serial port {source}");
+                    dbg!(&port);
+                    self.port = Some(port);
+
+                    Ok(())
+                }
+                Err(e) => Err(CameraState::Error(format!("Failed to open port: {e}"))),
+            }
+        } else {
+            Err(CameraState::Connected)
+        }
+    }
+
+    fn disconnect(&mut self) {
+        // port is closed once object is dropped
+        if self.port.is_some() {
+            self.port = None;
+        }
+    }
+}
+
+fn get_frame(port: &mut SerialPortVariant) -> Result<Vec<u8>, CameraState> {
+    // should always be lower than a full jpeg frame
+    let peek_buf_size = 256;
+    let leftover_threshold = 8192;
+
+    // peek into stream and retrieve header
+    let input: Result<(Vec<u8>, u16), _> = loop {
+        let data = match get_data(port.as_mut(), peek_buf_size) {
+            Ok(data) => data,
+            Err(e) => {
+                break Err(format!(
+                    "failed to read bytes from serial port buffer: {e:?}"
+                ));
+            }
+        };
+
+        trace!("read {} bytes during peek", data.len());
+
+        // look for ~6 bytes in buffer, hopefully finding a match
+        match parse_next_header(&data) {
+            Ok((input, len_data)) => break Ok((Vec::from(input), len_data)),
+            Err(nom::Err::Incomplete(needed)) => {
+                trace!("need to peek further into data stream: {needed:?}");
+                continue;
+            }
+            Err(nom::Err::Error(data)) | Err(nom::Err::Failure(data)) => {
+                error!("failed to read data stream: {:?}", data.code);
+                break Err(format!("failed to parse buffer via nom: {:?}", data.code));
+            }
+        };
+    };
+
+    // unpack remaining input and expected length of jpeg packet
+    let (input, len_data) = match input {
+        Ok(i) => i,
+        Err(e) => {
+            return Err(CameraState::Error(e.to_string()));
+        }
+    };
+
+    // fetch missing bytes for full packet
+    let missing_bytes = ((len_data as usize) - input.len()).max(0);
+    let input = if missing_bytes > 0 {
+        let missing = match get_data(port.as_mut(), missing_bytes) {
+            Ok(data) => data,
+            Err(e) => {
+                return Err(CameraState::Error(format!(
+                    "failed to read remaining bytes from serial port buffer: {e:?}"
+                )));
+            }
+        };
+        [input, missing].concat()
+    } else {
+        input
+    };
+
+    let result = match parse_jpeg_data(&input, len_data) {
+        Ok((_remaining, result)) => {
+            // todo: validate JPEG data? corrupted frames are currently possible
+            // image = { version = "0.25.6" }
+            // image::load_from_memory_with_format(result, image::ImageFormat::Jpeg)
+
+            Ok(Vec::from(result))
+        }
+        Err(nom::Err::Incomplete(needed)) => {
+            warn!("incomplete jpeg frame despite reading appropriate length: {needed:?}");
+            Err(CameraState::Error("incomplete jpeg frame".to_string()))
+        }
+        Err(nom::Err::Error(data)) | Err(nom::Err::Failure(data)) => {
+            error!("failed to read data stream: {:?}", data.code);
+
+            Err(CameraState::Error(format!(
+                "failed to read data stream: {:?}",
+                data.code
+            )))
+        }
+    };
+
+    // drop leftover data to keep in sync with reality
+    match port.bytes_to_read() {
+        Ok(leftover) if leftover > leftover_threshold as u32 => {
+            trace!("dropping leftover bytes: {leftover}");
+            if let Err(e) = port.clear(serialport::ClearBuffer::All) {
+                error!("failed to drop leftover bytes: {e:?}");
+            }
+        }
+        Err(e) => {
+            error!("failed to query leftover bytes in serial port: {e:?}");
+        }
+        _ => {}
+    }
+    result
+}
+
+fn get_data(port: &mut dyn SerialPort, buf_size: usize) -> io::Result<Vec<u8>> {
+    let mut buf = vec![0u8; buf_size];
+    port.read_exact(&mut buf)?;
+
+    Ok(buf)
+}
+
+fn parse_next_header(input: &[u8]) -> IResult<&[u8], u16> {
+    let (input, _preamble) = bytes::streaming::take_until(ETVR_HEADER_FRAME).parse(input)?;
+
+    sequence::preceded(
+        bytes::streaming::tag(ETVR_HEADER_FRAME),
+        number::streaming::le_u16,
+    )
+    .parse(input)
+}
+
+fn parse_jpeg_data(input: &[u8], len_data: u16) -> IResult<&[u8], &[u8]> {
+    bytes::streaming::take(len_data).parse_complete(input)
+}
+
+// todo: proper impls
+unsafe impl Send for OpenIrisCamera {}
+unsafe impl Sync for OpenIrisCamera {}

--- a/crates/camera/src/camera.rs
+++ b/crates/camera/src/camera.rs
@@ -1,15 +1,48 @@
-use std::sync::Arc;
-use std::sync::Mutex;
+use std::{
+    fmt::Debug,
+    sync::{Arc, atomic, mpsc},
+};
+
+use log::{debug, error, trace};
+use replace_with::replace_with_or_abort_and_return;
+
 use crate::{CameraHandler, CameraHandlers, CameraState};
 
+// number of frames that will be kept in the channel
+const BUFFERED_FRAMES: usize = 30;
+
+type BoxedHandler = Box<dyn CameraHandler>;
+
+#[derive(Debug)]
+pub struct Atomics {
+    should_stop: atomic::AtomicBool,
+    frame_rate: atomic::AtomicU16,
+    target_frame_rate: atomic::AtomicU16,
+}
+
+impl Atomics {
+    fn new(target_frame_rate: u16) -> Self {
+        Self {
+            should_stop: atomic::AtomicBool::new(false),
+            frame_rate: atomic::AtomicU16::new(0),
+            target_frame_rate: atomic::AtomicU16::new(target_frame_rate),
+        }
+    }
+}
+
+#[derive(Debug)]
+enum InternalState {
+    Waiting(BoxedHandler),
+    Connected {
+        thread: std::thread::JoinHandle<BoxedHandler>,
+        frame_rx: mpsc::Receiver<Vec<u8>>,
+    },
+}
+
+#[derive(Debug)]
 pub struct Camera {
-    frame: Arc<Mutex<Vec<u8>>>,
-    frame_rate: Arc<Mutex<u16>>,
-    should_stop: Arc<Mutex<bool>>,
-    target_frame_rate: Arc<Mutex<u16>>,
-    thread: std::thread::JoinHandle<()>,
-    camera_state: Arc<Mutex<CameraState>>,
-    handler: Arc<Mutex<Box<dyn CameraHandler>>>,
+    state: InternalState,
+    atomics: Arc<Atomics>,
 }
 
 impl Camera {
@@ -17,133 +50,184 @@ impl Camera {
         use crate::backends::*;
 
         #[allow(unreachable_patterns)]
-        let backend: Box<dyn CameraHandler> = match handler {
-            CameraHandlers::NoOp => {
-                Box::new(NoOpCamera::init())
-            }
-            CameraHandlers::OpenCV => {
-                Box::new(OpenCVCamera::init())
-            }
-            CameraHandlers::OpenIris => {
-                todo!();
-                // Box::new(OpenIrisCamera::init())
-            }
+        let backend: BoxedHandler = match handler {
+            CameraHandlers::NoOp => Box::new(NoOpCamera::init()),
+            CameraHandlers::OpenCV => Box::new(OpenCVCamera::init()),
+            CameraHandlers::OpenIris => Box::new(OpenIrisCamera::init()),
             _ => {
                 panic!("Unsupported camera handler");
             }
         };
 
-        return Self::from_camera_handler(backend, frame_rate);
+        Self::from_camera_handler(backend, frame_rate)
     }
 
-    pub fn from_camera_handler(handler: Box<dyn CameraHandler>, target_frame_rate: u16) -> Camera {
-        let frame = Arc::new(Mutex::new(vec![]));
-        let handler = Arc::new(Mutex::new(handler));
-        let should_stop = Arc::new(Mutex::new(false));
-        let frame_rate = Arc::new(Mutex::new(u16::MIN));
-        let target_frame_rate = Arc::new(Mutex::new(target_frame_rate));
-        let camera_state = Arc::new(Mutex::new(CameraState::Disconnected));
-
-        let thread = {
-            // Arc doesn't impl copy
-            let frame = frame.clone();
-            let handler = handler.clone();
-            let frame_rate = frame_rate.clone();
-            let should_stop = should_stop.clone();
-            let _camera_state = camera_state.clone();
-            let target_frame_rate = target_frame_rate.clone();
-            std::thread::spawn(move || {
-                loop {
-                    // Uhm might maybe max out the CPU's thread
-                    if *(should_stop.lock().unwrap()) {continue}
-
-                    let mut frame = frame.lock().unwrap();
-                    let mut handler = handler.lock().unwrap();
-                    let frame_time = std::time::Instant::now();
-                    let mut frame_rate = frame_rate.lock().unwrap();
-                    let mut _camera_state = _camera_state.lock().unwrap();
-                    let target_frame_rate = target_frame_rate.lock().unwrap();
-
-                    *frame = match handler.get_frame() {
-                        Ok(frame) => {frame}
-
-                        // TODO: proper error handling
-                        Err(_) => {continue}
-                    };
-
-                    *frame_rate = (1000 / frame_time.elapsed().as_millis().max(1)) as u16;
-                    let target_duration = std::time::Duration::from_millis(1000 / *target_frame_rate as u64);
-                    if frame_time.elapsed() < target_duration {
-                        std::thread::sleep(target_duration - frame_time.elapsed());
-                    }
-                }
-            })
-        };
-
-        return Self {
-            frame: frame,
-            thread: thread,
-            handler: handler,
-            frame_rate: frame_rate,
-            should_stop: should_stop,
-            camera_state: camera_state,
-            target_frame_rate: target_frame_rate,
-        };
+    pub fn from_camera_handler(handler: BoxedHandler, target_frame_rate: u16) -> Camera {
+        Self {
+            state: InternalState::Waiting(handler),
+            atomics: Arc::new(Atomics::new(target_frame_rate)),
+        }
     }
 
     /// Retrieves the current most recent frame from the camera
     /// - Returns an error if the camera is not connected
     pub fn get_frame(&self) -> Result<Vec<u8>, CameraState> {
-        if *(self.camera_state.lock().unwrap()) != CameraState::Connected {
-            return Err(self.camera_state.lock().unwrap().clone());
+        match &self.state {
+            InternalState::Waiting(..) => Err(CameraState::Disconnected),
+            InternalState::Connected {
+                thread: _,
+                frame_rx,
+            } => match frame_rx.recv() {
+                Ok(mut frame) => Ok(std::mem::take(&mut frame)),
+                Err(e) => Err(CameraState::Error(e.to_string())),
+            },
         }
-
-        // drain to avoid an extra unecessary clone of the data
-        return Ok(self.frame.lock().unwrap().drain(..).collect());
     }
 
-    pub fn connect(&self, source: String) -> Result<(), CameraState> {
-        let mut handler = self.handler.lock().unwrap();
-        let mut camera_state = self.camera_state.lock().unwrap();
-        *camera_state = CameraState::Connecting;
+    pub fn connect(&mut self, source: String) -> Result<(), CameraState> {
+        replace_with_or_abort_and_return(&mut self.state, |state| match state {
+            InternalState::Connected { .. } => {
+                (Err(CameraState::Error("Already connected".into())), state)
+            }
+            InternalState::Waiting(mut handler) => {
+                // rationale: we're handing off the handler to the [`handler_recv`] thread
+                // and transitioning our state to [`InternalState::Connected`], where handler is
+                // not needed.
+                // the handle later gets reclaimed in [`Camera::disconnect`], see return value
+                // of the thread binding in current scope.
 
-        match handler.connect(source) {
-            Ok(_) => {
-                *camera_state = CameraState::Connected;
-                return Ok(());
+                if let Err(e) = handler.connect(source) {
+                    return (Err(e), InternalState::Waiting(handler));
+                };
+
+                let (frame_tx, frame_rx) = mpsc::sync_channel(BUFFERED_FRAMES);
+                let thread = handler_recv(handler, frame_tx, self.atomics.clone());
+
+                (Ok(()), InternalState::Connected { thread, frame_rx })
             }
-            Err(e) => {
-                *camera_state = e.clone();
-                return Err(e);
-            }
-        }
+        })
     }
 
     /// Disconnects the camera
-    pub fn disconnect(&self) {
-        *self.should_stop.lock().unwrap() = true;
-        self.handler.lock().unwrap().disconnect();
+    pub fn disconnect(&mut self) -> Result<(), CameraState> {
+        replace_with_or_abort_and_return(&mut self.state, |state| match state {
+            InternalState::Connected { thread, frame_rx } => {
+                self.atomics
+                    .should_stop
+                    .store(true, atomic::Ordering::Relaxed);
+
+                // purge frame_rx by consuming all remaining elements
+                let count = frame_rx.recv().iter().count();
+                trace!("purged {count} frames from receive queue");
+
+                // reclaim our injected camera implementation handler from thread
+                let handler = thread.join().expect("receive thread has panicked");
+                trace!("reclaimed handler from thread");
+
+                (Ok(()), InternalState::Waiting(handler))
+            }
+            state => (
+                Err(CameraState::Error(format!(
+                    "Cannot disconnect during this state: {state:?}"
+                ))),
+                state,
+            ),
+        })
     }
 
     /// Returns the current frame rate of the camera
     pub fn frame_rate(&self) -> u16 {
-        return *self.frame_rate.lock().unwrap()
+        self.atomics.frame_rate.load(atomic::Ordering::Relaxed)
     }
 
     /// Returns the target frame rate of the camera
     pub fn target_frame_rate(&self) -> u16 {
-        return *self.target_frame_rate.lock().unwrap()
+        self.atomics
+            .target_frame_rate
+            .load(atomic::Ordering::Relaxed)
     }
 
     /// Set the target frame rate the camera should attempt to achieve
     pub fn set_target_frame_rate(&self, target_frame_rate: u16) {
-        *self.target_frame_rate.lock().unwrap() = target_frame_rate;
+        self.atomics
+            .target_frame_rate
+            .store(target_frame_rate, atomic::Ordering::Relaxed)
     }
+}
 
-    pub fn shutdown(self) {
-        self.handler.lock().unwrap().disconnect();
-        // This should kill the thread loop...
-        self.thread.thread().unpark();
-        self.thread.join().unwrap();
+pub fn handler_recv(
+    mut handler: BoxedHandler,
+    frame_tx: mpsc::SyncSender<Vec<u8>>,
+    atomics: Arc<Atomics>,
+) -> std::thread::JoinHandle<BoxedHandler> {
+    std::thread::spawn(move || {
+        loop {
+            if atomics.should_stop.load(atomic::Ordering::Relaxed) {
+                break;
+            }
+
+            let target_fps = atomics.target_frame_rate.load(atomic::Ordering::Relaxed) as u64;
+            let frame_time = std::time::Instant::now();
+
+            let frame = match handler.get_frame() {
+                Ok(frame) => frame,
+                Err(_) => {
+                    // TODO: proper error handling
+                    // error!("failed to fetch frame: {e:?}");
+                    continue;
+                }
+            };
+
+            if let Err(e) = frame_tx.send(frame) {
+                // todo: abort thread here? this state should never be hit
+                error!("failed to send frame to internal channel: {e:?}");
+            }
+
+            // sleep for consistent FPS
+            let target_duration = std::time::Duration::from_millis(1000 / target_fps);
+            if frame_time.elapsed() < target_duration {
+                std::thread::sleep(target_duration - frame_time.elapsed());
+            }
+
+            let elapsed = frame_time.elapsed().as_millis().max(1);
+            debug!("{} fps, elapsed {} ms", 1000 / elapsed, elapsed);
+
+            atomics
+                .frame_rate
+                .store((1000 / elapsed) as u16, atomic::Ordering::Relaxed);
+        }
+
+        handler
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_state_transitions() {
+        let handler = CameraHandlers::NoOp;
+        let source: String = "COM13".into();
+
+        // camera was created and is waiting for a connection
+        let mut camera = Camera::new(handler, 30);
+        assert!(matches!(camera.state, InternalState::Waiting(..)));
+
+        // camera is in connect state with valid thread handle
+        camera
+            .connect(source)
+            .expect("no-op connect should always succeed");
+        assert!(matches!(camera.state, InternalState::Connected { .. }));
+        let InternalState::Connected { ref thread, .. } = camera.state else {
+            unreachable!()
+        };
+        assert!(!thread.is_finished());
+
+        // disconnect should move camera into waiting state
+        camera
+            .disconnect()
+            .expect("disconnect should always succeed");
+        assert!(matches!(camera.state, InternalState::Waiting(..)))
     }
 }

--- a/crates/camera/src/handler.rs
+++ b/crates/camera/src/handler.rs
@@ -1,5 +1,6 @@
-#[derive(Debug, Clone)]
-#[derive(PartialEq, Eq)]
+use std::fmt::Debug;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CameraState {
     Timeout,
     Connected,
@@ -14,25 +15,30 @@ pub enum CameraState {
 /// a way to communicate and manage different camera types
 /// ## Safety
 /// - The handler is expected to be thread safe and implement `Send` + `Sync`
-/// - `CameraHandler::Init` is garenteed to be called before any other methods
-///    - The init function will only ever be called once when allocating the handler
-pub trait CameraHandler: Send + Sync {
+/// - `CameraHandler::Init` is guaranteed to be called before any other methods
+///    - The init function will only ever be called once when allocating the
+///      handler
+pub trait CameraHandler: Send + Sync + Debug {
     /// Initializes the camera backend
     /// - This method is only called a single time at startup
-    /// - All variables should be initialized and allocated here
-    ///   The backend should not attempt to connect to the camera at this stage
-    fn init() -> Self where Self: Sized;
+    /// - All variables should be initialized and allocated here The backend
+    ///   should not attempt to connect to the camera at this stage
+    fn init() -> Self
+    where
+        Self: Sized;
 
     // FIXME: this needs a concrete type
     fn get_frame(&mut self) -> Result<Vec<u8>, CameraState>;
 
     /// Attempts to establish a connection to the camera
-    /// - Backends should try to capture a single frame and discard it
-    ///   to ensure proper functionality and make sure the camera is working
+    /// - Backends should try to capture a single frame and discard it to ensure
+    ///   proper functionality and make sure the camera is working
     fn connect(&mut self, source: String) -> Result<(), CameraState>;
 
     /// Disconnects the camera and releases any resources
-    /// - Disconnecting is meant to be able to be reversed via `CameraHandler::connect`
-    /// - Release any active connections and free up any resources but dont dispose of the handler
+    /// - Disconnecting is meant to be able to be reversed via
+    ///   `CameraHandler::connect`
+    /// - Release any active connections and free up any resources but dont
+    ///   dispose of the handler
     fn disconnect(&mut self);
 }

--- a/crates/camera/src/lib.rs
+++ b/crates/camera/src/lib.rs
@@ -1,7 +1,7 @@
+mod backends;
 mod camera;
 mod handler;
-mod backends;
 
-pub use handler::*;
-pub use camera::Camera;
 pub use backends::CameraHandlers;
+pub use camera::Camera;
+pub use handler::*;


### PR DESCRIPTION
- removed [package] from workspace as that conflicted with `cargo metadata` resolving
- refactor main camera struct to use channels and background receive thread
- state transitions via enum, replacing most Arcs and locking
- OpenIris serial implementation via `nom` and `serialport`
- (hopefully) complete & working guide for compiling on Windows

Remaining questions/things:
- what's the `logger` crate for; is [`tracing`](https://crates.io/crates/tracing) unavailable?
- for some reason the port is initialized with 9600 baud on my machine, is the high rate necessary at all?
- the received JPEG data should _probably_ be validated
  - see `openiris::get_frame` on L138
  - it works on my machine:tm:, most of the time
- `Send` and `Sync` implementations are missing entirely
- async via tokio(?) would be neater, if available on target platforms
  - list of target platforms should probably be documented somewhere

----

Under good conditions, this `impl` achieves 52~58 FPS on my machine, just like the Python implementation, until the ESPs start overheating. Can post a shoddy `axum`-based MJPEG streaming server if you'd like to test it yourself in VLC/mpv with some ready-to-use example.